### PR TITLE
Update formatting lib, fix nuget binary reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ temp/
 
 # Test results produced by build
 TestResults.xml
+
+# Nuget outputs
+nuget/*.nupkg

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -20,7 +20,7 @@ let info =
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../packages/FSharp.Formatting.2.1.6/lib/net40"
+#I "../../packages/FSharp.Formatting.2.2.11-beta/lib/net40"
 #I "../../packages/RazorEngine.3.3.0/lib/net40/"
 #r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
 #r "../../packages/FAKE/tools/FakeLib.dll"
@@ -48,7 +48,7 @@ let content    = __SOURCE_DIRECTORY__ @@ "../content"
 let output     = __SOURCE_DIRECTORY__ @@ "../output"
 let files      = __SOURCE_DIRECTORY__ @@ "../files"
 let templates  = __SOURCE_DIRECTORY__ @@ "templates"
-let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.1.6/"
+let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.2.11-beta/"
 let docTemplate = formatting @@ "templates/docpage.cshtml"
 
 // Where to look for *.csproj templates (in this order)
@@ -60,7 +60,7 @@ let layoutRoots =
 let copyFiles () =
   CopyRecursive files output true |> Log "Copying file: "
   ensureDirectory (output @@ "content")
-  CopyRecursive (formatting @@ "content") (output @@ "content") true 
+  CopyRecursive (formatting @@ "styles") (output @@ "content") true 
     |> Log "Copying styles and scripts: "
 
 // Build API reference from XML comments

--- a/docs/tools/packages.config
+++ b/docs/tools/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Formatting" version="2.1.6" targetFramework="net45" />
+  <package id="FSharp.Formatting" version="2.2.11-beta" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
 </packages>

--- a/nuget/FSharp.ProjectTemplate.nuspec
+++ b/nuget/FSharp.ProjectTemplate.nuspec
@@ -17,6 +17,6 @@
     <dependencies />
   </metadata>
   <files>
-    <file src="FSharp.ProjectTemplate.dll" target="lib/net40" />
+    <file src="..\bin\FSharp.ProjectTemplate.dll" target="lib/net40" />
   </files>
 </package>


### PR DESCRIPTION
-  Updates to a new version of F# formatting (it is marked as beta, but works nicely). Also, the new package now renames `content` folder with default styles to `styles` (so that the files are not automatically added to your solution by Visual Studio)
- The paths in the `nuspec` file need to be relative to the nuspec folder (this is due to a recent change in FAKE).
