### PR TITLE
Demonstrate new features in FSharp.Formatting

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -8,20 +8,23 @@ let referenceBinaries = [ "FSharp.ProjectTemplate.dll" ]
 // Web site location for the generated documentation
 let website = "/FSharp.ProjectScaffold"
 
+let githubLink = "http://github.com/fsprojects/FSharp.ProjectScaffold"
+
 // Specify more information about your project
 let info =
   [ "project-name", "FSharp.ProjectScaffold"
     "project-author", "Your Name"
     "project-summary", "A short summary of your project"
-    "project-github", "http://github.com/fsprojects/FSharp.ProjectScaffold"
+    "project-github", githubLink
     "project-nuget", "http://nuget.com/packages/FSharp.ProjectScaffold" ]
 
 // --------------------------------------------------------------------------------------
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../packages/FSharp.Formatting.2.2.11-beta/lib/net40"
-#I "../../packages/RazorEngine.3.3.0/lib/net40/"
+#I "../../packages/FSharp.Formatting.2.3.5-beta/lib/net40"
+#I "../../packages/RazorEngine.3.3.0/lib/net40"
+#I "../../packages/FSharp.Compiler.Service.0.0.11-alpha/lib/net40"
 #r "../../packages/Microsoft.AspNet.Razor.2.0.30506.0/lib/net40/System.Web.Razor.dll"
 #r "../../packages/FAKE/tools/FakeLib.dll"
 #r "RazorEngine.dll"
@@ -48,7 +51,7 @@ let content    = __SOURCE_DIRECTORY__ @@ "../content"
 let output     = __SOURCE_DIRECTORY__ @@ "../output"
 let files      = __SOURCE_DIRECTORY__ @@ "../files"
 let templates  = __SOURCE_DIRECTORY__ @@ "templates"
-let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.2.11-beta/"
+let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting.2.3.5-beta/"
 let docTemplate = formatting @@ "templates/docpage.cshtml"
 
 // Where to look for *.csproj templates (in this order)
@@ -69,7 +72,10 @@ let buildReference () =
   for lib in referenceBinaries do
     MetadataFormat.Generate
       ( bin @@ lib, output @@ "reference", layoutRoots, 
-        parameters = ("root", root)::info )
+        parameters = ("root", root)::info,
+        sourceRepo = githubLink @@ "tree/master",
+        sourceFolder = __SOURCE_DIRECTORY__ @@ ".." @@ "..",
+        publicOnly = true )
 
 // Build documentation from `fsx` and `md` files in `docs/content`
 let buildDocumentation () =

--- a/docs/tools/packages.config
+++ b/docs/tools/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Formatting" version="2.2.11-beta" targetFramework="net45" />
+  <package id="FSharp.Formatting" version="2.3.5-beta" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
+  <package id="FSharp.Compiler.Service" version="0.0.11-alpha" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I upgrade FSharp.Formatting to version 2.3.5-beta which uses more up-to-date backend, `FSharp.Compiler.Service`.

Two new features have been shown in generating API docs:
- Generate links to GitHub source of all functions and members. See detailed description at http://tpetricek.github.io/FSharp.Formatting/metadata.html.
- Filter to display only public members in documentation.

This would provide better default API doc generation usage.

This is resulted from brief discussion at https://github.com/tpetricek/FSharp.Formatting/pull/81#issuecomment-32830684

cc @forki
