### PR TITLE
Remove the float style from the logo image

### DIFF
--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -34,7 +34,7 @@
           @RenderBody()
         </div>
         <div class="span3">
-          <img src="img/logo.png" alt="F# Project" style="float:left;width:150px;margin:10px" />  
+          <img src="img/logo.png" alt="F# Project" style="width:150px;margin:10px" />  
           <ul class="nav nav-list" id="menu">
             <li class="nav-header">@Properties["project-name"]</li>
             <li><a href="@Root/index.html">Home page</a></li>


### PR DESCRIPTION
The `float: left;` style rule can cause a very strange looking alignment.
