### PR TITLE
Removed temp generated fsharpi file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,12 +3,4 @@ if [ ! -f packages/FAKE/tools/FAKE.exe ]; then
   mono .nuget/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion
 fi
 #workaround assembly resolution issues in build.fsx
-export FSHARPI=`which fsharpi`
-cat - > fsharpi <<"EOF"
-#!/bin/bash
-libdir=$PWD/packages/FAKE/tools/
-$FSHARPI --lib:$libdir $@
-EOF
-chmod +x fsharpi
 mono packages/FAKE/tools/FAKE.exe build.fsx $@
-rm fsharpi


### PR DESCRIPTION
It seems that my pull request didn't get created correctly. Sorry if I made the same pull request twice.

First, it seems that this is not necessary, probably because FAKE 3.0 uses the
F# compiler services instead of the fsharpi executable.

Second, because the FAKE command was not the last command in the script, any
failure from the build script would not cause the 'build.sh' shell script to
return an error message, and e.g. a build server would see the build outcome as
a success.
