### PR TITLE
Move NUnit dependency and invoke nuget always in cmd script

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit.Runners" version="2.6.3" />
-</packages>

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
-if [ ! -e packages/FAKE/tools/FAKE.exe ]; then 
-  mono .nuget/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion -version "3.2.1"
-fi
-
-if [ ! -e packages/SourceLink.Fake/Tools/Fake.fsx ]; then
-  mono .nuget/NuGet.exe install SourceLink.Fake -OutputDirectory packages -ExcludeVersion
-fi
+mono .nuget/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion
+mono .nuget/NuGet.exe install SourceLink.Fake -OutputDirectory packages -ExcludeVersion
 
 if [ ! -e build.fsx ]; then 
   mono packages/FAKE/tools/FAKE.exe init.fsx

--- a/tests/FSharp.ProjectTemplate.Tests/packages.config
+++ b/tests/FSharp.ProjectTemplate.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
+  <package id="NUnit.Runners" version="2.6.3" />
 </packages>


### PR DESCRIPTION
I noticed that the `build.sh` file has a hard-coded version of FAKE. This does not sound right to me.. or is there any reason for that?

Also, `build.cmd` always triggers `nuget install`, which will automatically update FAKE if you have an old version. It sounds sensible to do this on *nix too.

@caindy - Could you please check that this works well on a Mac? (Or in case I'm missing something, let me know what the problem with latest FAKE was...)
