### PR TITLE
renamed nuspec file for #64

### DIFF
--- a/init.fsx
+++ b/init.fsx
@@ -135,11 +135,13 @@ let rec filesToReplace dir = seq {
   yield! Directory.GetFiles(dir, "*.fsproj")
   yield! Directory.GetFiles(dir, "*.fs")
   yield! Directory.GetFiles(dir, "*.fsx")
+  yield! Directory.GetFiles(dir, "*.nuspec")
   yield! Directory.EnumerateDirectories(dir) |> Seq.collect filesToReplace
 }
 let updateFiles = 
   seq { yield solutionFile 
         yield! filesToReplace <| localFile "src"
+        yield! filesToReplace <| localFile "nuget"
         yield! filesToReplace <| localFile "tests" } 
         |> Seq.map replaceContent 
         |> Seq.iter print


### PR DESCRIPTION
related to issue #64

Unfortunately, the NuGet task seems to be broken, so this isn't ready for primetime on OSX. The path interpolation doesn't seem to be cross-platform.

```
Starting Target: NuGet (==> All)
Creating .nuspec file at /Users/brad/DEV/ProjectScaffold/NuGet/name.1.0.nuspec
Created nuspec file /Users/brad/DEV/ProjectScaffold/NuGet/name.1.0.nuspec
mono  /Users/brad/DEV/ProjectScaffold/.nuget/NuGet.exe pack -Version 1.0 -OutputDirectory "/Users/brad/DEV/ProjectScaffold/bin" "name.1.0.nuspec"
Attempting to build package from 'name.1.0.nuspec'.
Directory '/Users/brad/DEV/ProjectScaffold/nuget/..\' not found.
Running build failed.
Error:
System.Exception: Error during NuGet package creation. /Users/brad/DEV/ProjectScaffold/.nuget/NuGet.exe pack -Version 1.0 -OutputDirectory "/Users/brad/DEV/ProjectScaffold/bin" "name.1.0.nuspec"
  at Fake.NuGetHelper.NuGet (Microsoft.FSharp.Core.FSharpFunc`2 setParams, System.String nuspecFile) [0x00000] in <filename unknown>:0
  at FSI_0001.Build+clo@160-11.Invoke (Microsoft.FSharp.Core.Unit _arg6) [0x00000] in <filename unknown>:0
  at Fake.TargetHelper+targetFromTemplate@145[Microsoft.FSharp.Core.Unit].Invoke (Microsoft.FSharp.Core.Unit unitVar0) [0x00000] in <filename unknown>:0
  at Fake.TargetHelper.runTarget@314 (System.String targetName) [0x00000] in <filename unknown>:0
```
