### PR TITLE
Add missing reference to MONO_VERSION env variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     - MONO_VERSION="3.4.0"
 
 install:
-  - wget "http://download.mono-project.com/archive/3.4.0/macos-10-x86/MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg"
+  - wget "http://download.mono-project.com/archive/${MONO_VERSION}/macos-10-x86/MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg"
   - sudo installer -pkg "MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg" -target /
 
 script: 


### PR DESCRIPTION
Just noticed this when I upgraded to Mono 3.6.0. Thought this would help anyone else starting out with Mono other than 3.4.0.
