### PR TITLE
Fixing comments in the example lib so it actually works with Fsharp.Form...

### DIFF
--- a/src/FSharp.ProjectTemplate/Library.fs
+++ b/src/FSharp.ProjectTemplate/Library.fs
@@ -1,16 +1,17 @@
 ﻿namespace FSharp.ProjectTemplate
 
-// Documentation for my library
-//
-// ## Example
-//
-//     let h = Library.hello 1
-//     printfn "%d" h
-//
+/// Documentation for my library
+///
+/// ## Example
+///
+///     let h = Library.hello 1
+///     printfn "%d" h
+///
 module Library = 
   
-  // Returns 42
-  //
-  // ## Parameters
-  //  - `num` - whatever
+  /// Returns 42
+  ///
+  /// ## Parameters
+  ///  - `num` - whatever
   let hello num = 42
+


### PR DESCRIPTION
Noticed that the generated docs (API reference) when running the initial build did not contain any actual data.
Fixed the commenting style in the library to triple slash to make sure generated docs have content.
