### PR TITLE
Set libDirs to help API reference generation

### DIFF
--- a/docs/tools/generate.template
+++ b/docs/tools/generate.template
@@ -78,7 +78,7 @@ let buildReference () =
       parameters = ("root", root)::info,
       sourceRepo = githubLink @@ "tree/master",
       sourceFolder = __SOURCE_DIRECTORY__ @@ ".." @@ "..",
-      publicOnly = true )
+      publicOnly = true, libDirs = [bin] )
 
 // Build documentation from `fsx` and `md` files in `docs/content`
 let buildDocumentation () =


### PR DESCRIPTION
I had to set `libDirs` for all my projects to get even close to generating API reference docs.
