### PR TITLE
Updated main docs template to use generated license and release notes

### DIFF
--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -41,8 +41,8 @@
             <li class="divider"></li>
             <li><a href="@Properties["project-nuget"]">Get Library via NuGet</a></li>
             <li><a href="@Properties["project-github"]">Source Code on GitHub</a></li>
-            <li><a href="@Properties["project-github"]/blob/master/LICENSE.txt">License</a></li>
-            <li><a href="@Properties["project-github"]/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
+            <li><a href="@Root/license.html">License</a></li>
+            <li><a href="@Root/release-notes.html">Release Notes</a></li>
             
             <li class="nav-header">Getting started</li>
             <li><a href="@Root/tutorial.html">Sample tutorial</a></li>


### PR DESCRIPTION
I noticed that the generated documentation included a nice HTML version of release notes and license, but the main template linked to raw versions from github.

This fix changes the template to use the shiny generated html files.
