### PR TITLE
Explicitly setting the correct nuget.exe

### DIFF
--- a/build.template
+++ b/build.template
@@ -158,6 +158,7 @@ Target "SourceLink" (fun _ ->
 Target "NuGet" (fun _ ->
     NuGet (fun p ->
         { p with
+            ToolPath = "packages/NuGet.CommandLine/tools/Nuget.exe"
             Authors = authors
             Project = project
             Summary = summary


### PR DESCRIPTION
Apparently some packages (_cough_ MySql.Data, 5.1.7.0 _cough_) for some reason have a nuget.exe in them, and it is not exactly the latest version.

By default, the Fake nuget helper searches subdirectories(?) to find the first nuget.exe there is and uses that. Problems occurs when it is a really old version that crashes for unknown reasons due to complicated _new_ fields like _release notes_.

(Yes I have spent way too much time finding the cause of why my nuget package would not build today.)

Anyway, this change explicitly sets the toolpath used in build.fsx to the nuget.exe from the nuget.commandline package. (So hopefully no-one else have to spend time troubleshooting this).
