### PR TITLE
replace FSharp.ProjectTemplate with provided project name

### DIFF
--- a/init.fsx
+++ b/init.fsx
@@ -152,7 +152,8 @@ let updateFiles =
   seq { yield solutionFile 
         yield! filesToReplace <| localFile "src"
         yield! filesToReplace <| localFile "nuget"
-        yield! filesToReplace <| localFile "tests" } 
+        yield! filesToReplace <| localFile "tests"
+        yield! filesToReplace <| localFile "docs/content" } 
         |> Seq.map replaceContent 
         |> Seq.iter print
 


### PR DESCRIPTION
Currently `FSharp.ProjectTemplate` doesn't get replaced in documentation (`index.fsx`, `tutorial.fsx`) by the project name provided during initialization.
