### PR TITLE
Add "add language specific documents" feature.

### DIFF
--- a/build.template
+++ b/build.template
@@ -180,18 +180,23 @@ Target "GenerateReferenceDocs" (fun _ ->
       failwith "generating reference documentation failed"
 )
 
-let generateHelp fail =
-    if executeFSIWithArgs "docs/tools" "generate.fsx" ["--define:RELEASE"; "--define:HELP"] [] then
+let generateHelp' fail debug =
+    let args =
+        if debug then ["--define:HELP"]
+        else ["--define:RELEASE"; "--define:HELP"]
+    if executeFSIWithArgs "docs/tools" "generate.fsx" args [] then
         traceImportant "Help generated"
     else
         if fail then
             failwith "generating help documentation failed"
         else
             traceImportant "generating help documentation failed"
-    
+
+let generateHelp fail =
+    generateHelp' fail false
 
 Target "GenerateHelp" (fun _ ->
-    DeleteFile "docs/content/release-notes.md"    
+    DeleteFile "docs/content/release-notes.md"
     CopyFile "docs/content/" "RELEASE_NOTES.md"
     Rename "docs/content/release-notes.md" "docs/content/RELEASE_NOTES.md"
 
@@ -202,6 +207,17 @@ Target "GenerateHelp" (fun _ ->
     generateHelp true
 )
 
+Target "GenerateHelpDebug" (fun _ ->
+    DeleteFile "docs/content/release-notes.md"
+    CopyFile "docs/content/" "RELEASE_NOTES.md"
+    Rename "docs/content/release-notes.md" "docs/content/RELEASE_NOTES.md"
+
+    DeleteFile "docs/content/license.md"
+    CopyFile "docs/content/" "LICENSE.txt"
+    Rename "docs/content/license.md" "docs/content/LICENSE.txt"
+
+    generateHelp' true true
+)
 
 Target "KeepRunning" (fun _ ->    
     use watcher = new FileSystemWatcher(DirectoryInfo("docs/content").FullName,"*.*")
@@ -220,6 +236,46 @@ Target "KeepRunning" (fun _ ->
 )
 
 Target "GenerateDocs" DoNothing
+
+let createIndexFsx lang =
+    let content = """(*** hide ***)
+// This block of code is omitted in the generated HTML documentation. Use 
+// it to define helpers that you do not want to show in the documentation.
+#I "../../../bin"
+
+(**
+F# Project Scaffold ({0})
+=========================
+*)
+"""
+    let targetDir = "docs/content" @@ lang
+    let targetFile = targetDir @@ "index.fsx"
+    ensureDirectory targetDir
+    System.IO.File.WriteAllText(targetFile, System.String.Format(content, lang))
+
+Target "AddLangDocs" (fun _ ->
+    let args = System.Environment.GetCommandLineArgs()
+    if args.Length < 4 then
+        failwith "Language not specified."
+
+    args.[3..]
+    |> Seq.iter (fun lang ->
+        if lang.Length <> 2 && lang.Length <> 3 then
+            failwithf "Language must be 2 or 3 characters (ex. 'de', 'fr', 'ja', 'gsw', etc.): %s" lang
+
+        let templateFileName = "template.cshtml"
+        let templateDir = "docs/tools/templates"
+        let langTemplateDir = templateDir @@ lang
+        let langTemplateFileName = langTemplateDir @@ templateFileName
+
+        if System.IO.File.Exists(langTemplateFileName) then
+            failwithf "Documents for specified language '%s' have already been added." lang
+
+        ensureDirectory langTemplateDir
+        Copy langTemplateDir [ templateDir @@ templateFileName ]
+
+        createIndexFsx lang)
+)
 
 // --------------------------------------------------------------------------------------
 // Release Scripts
@@ -283,6 +339,9 @@ Target "All" DoNothing
   ==> "GenerateHelp"
   ==> "GenerateReferenceDocs"
   ==> "GenerateDocs"
+
+"CleanDocs"
+  ==> "GenerateHelpDebug"
 
 "GenerateHelp"
   ==> "KeepRunning"

--- a/docs/tools/generate.template
+++ b/docs/tools/generate.template
@@ -56,9 +56,17 @@ let formatting = __SOURCE_DIRECTORY__ @@ "../../packages/FSharp.Formatting/"
 let docTemplate = formatting @@ "templates/docpage.cshtml"
 
 // Where to look for *.csproj templates (in this order)
-let layoutRoots =
-  [ templates; formatting @@ "templates"
-    formatting @@ "templates/reference" ]
+let layoutRootsAll = new System.Collections.Generic.Dictionary<string, string list>()
+layoutRootsAll.Add("en",[ templates; formatting @@ "templates"
+                          formatting @@ "templates/reference" ])
+subDirectories (directoryInfo templates)
+|> Seq.iter (fun d ->
+                let name = d.Name
+                if name.Length = 2 || name.Length = 3 then
+                    layoutRootsAll.Add(
+                            name, [templates @@ name
+                                   formatting @@ "templates"
+                                   formatting @@ "templates/reference" ]))
 
 // Copy static files and CSS + JS from F# Formatting
 let copyFiles () =
@@ -74,7 +82,7 @@ let buildReference () =
     referenceBinaries
     |> List.map (fun lib-> bin @@ lib)
   MetadataFormat.Generate
-    ( binaries, output @@ "reference", layoutRoots, 
+    ( binaries, output @@ "reference", layoutRootsAll.["en"],
       parameters = ("root", root)::info,
       sourceRepo = githubLink @@ "tree/master",
       sourceFolder = __SOURCE_DIRECTORY__ @@ ".." @@ "..",
@@ -85,6 +93,14 @@ let buildDocumentation () =
   let subdirs = Directory.EnumerateDirectories(content, "*", SearchOption.AllDirectories)
   for dir in Seq.append [content] subdirs do
     let sub = if dir.Length > content.Length then dir.Substring(content.Length + 1) else "."
+    let langSpecificPath(lang, path:string) =
+        path.Split([|'/'; '\\'|], System.StringSplitOptions.RemoveEmptyEntries)
+        |> Array.exists(fun i -> i = lang)
+    let layoutRoots =
+        let key = layoutRootsAll.Keys |> Seq.tryFind (fun i -> langSpecificPath(i, dir))
+        match key with
+        | Some lang -> layoutRootsAll.[lang]
+        | None -> layoutRootsAll.["en"] // "en" is the default language
     Literate.ProcessDirectory
       ( dir, docTemplate, output @@ sub, replacements = ("root", root)::info,
         layoutRoots = layoutRoots )


### PR DESCRIPTION
I added "add language specific documents" feature: `AddLangDocs` target.
And to enable to debug generated documents easier, added `GenerateHelpDebug` target.
## Usage
### Add new language specific documents

Run the following command to add `ja` (Japanese) documents for instance:

```
build.cmd AddLangDocs ja
```
### Add new multiple language specific documents

`AddLangDocs` target accepts multiple languages, so we can do like following:

```
build.cmd AddLangDocs de fr ja
```
### Build documents that can be seen locally

Run `GenerateHelpDebug` target:

```
build.cmd GenerateHelpDebug
```
## Details
### AddLangDocs

`AddLangDocs` will add 2 files under `docs` directory:
1. `docs/tools/templates/<lang>/template.cshtml`
2. `docs/content/<lang>/index.fsx`

`<lang>/template.cshtml` will be created by copying from the current `docs/tools/templates/template.cshtml`.
On the other hand, `<lang>/index.fsx` will be generated by `build.fsx` because I don't think that `docs/content/index.fsx` has always been there.

When we specify already-created language (i.e. already exists `docs/tools/templates/<lang>/template.cshtml`),
build will fail.
### GenerateHelpDebug

The difference between `GenerateHelp` is one thing: `--define:RELEASE` won't be specified when running `docs/tools/generate.fsx`.

That's all.
Sorry for the long description.
Thanks,
