### PR TITLE
build.template for mono is using the wrong case for loading Fake.fsx

### DIFF
--- a/build.template
+++ b/build.template
@@ -12,7 +12,7 @@ open System
 open System.IO
 #if MONO
 #else
-#load "packages/SourceLink.Fake/Tools/Fake.fsx"
+#load "packages/SourceLink.Fake/tools/Fake.fsx"
 open SourceLink
 #endif
 

--- a/docs/tools/generate.template
+++ b/docs/tools/generate.template
@@ -25,6 +25,7 @@ let info =
 #I "../../packages/FSharp.Formatting/lib/net40"
 #I "../../packages/RazorEngine/lib/net40"
 #I "../../packages/FSharp.Compiler.Service/lib/net40"
+#I "../../packages/FAKE/tools"
 #r "../../packages/FAKE/tools/NuGet.Core.dll"
 #r "../../packages/FAKE/tools/FakeLib.dll"
 #r "RazorEngine.dll"

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,5 +6,6 @@ nuget NUnit.Runners
 nuget Nuget.CommandLine
 nuget FAKE
 nuget SourceLink.Fake
+nuget RazorEngine
 
 github fsharp/FAKE modules/Octokit/Octokit.fsx


### PR DESCRIPTION
This issue casuses a problem when using emacs and fsharp mode on mono where the file cannot be found.  packages/SourceLink.Fake/Tools/Fake.fsx should be packages/SourceLink.Fake/tools/Fake.fsx