### PR TITLE
Update F# Formatting and reference via load script

### DIFF
--- a/docs/tools/generate.template
+++ b/docs/tools/generate.template
@@ -22,18 +22,9 @@ let info =
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../packages/FSharpVSPowerTools.Core/lib/net45"
-#I "../../packages/FSharp.Formatting/lib/net40"
-#I "../../packages/RazorEngine/lib/net40"
-#I "../../packages/FSharp.Compiler.Service/lib/net40"
+#load "../../packages/FSharp.Formatting/FSharp.Formatting.fsx"
 #r "../../packages/FAKE/tools/NuGet.Core.dll"
 #r "../../packages/FAKE/tools/FakeLib.dll"
-#r "FSharpVSPowerTools.Core.dll"
-#r "RazorEngine.dll"
-#r "System.Web.Razor.dll"
-#r "FSharp.Literate.dll"
-#r "FSharp.CodeFormat.dll"
-#r "FSharp.MetadataFormat.dll"
 open Fake
 open System.IO
 open Fake.FileHelper

--- a/paket.lock
+++ b/paket.lock
@@ -3,7 +3,7 @@ NUGET
   specs:
     FAKE (3.14.9)
     FSharp.Compiler.Service (0.0.82)
-    FSharp.Formatting (2.7.1)
+    FSharp.Formatting (2.7.4)
       FSharp.Compiler.Service (>= 0.0.82)
       FSharpVSPowerTools.Core (>= 1.7.0)
     FSharpVSPowerTools.Core (1.7.0)


### PR DESCRIPTION
The most recent version of F# Formatting includes a load script, which makes referencing the library easier and also avoids future incompatibilities when we change the dependencies (previously, you had to add `#I "...whatever_new_dependency..."`, which is now done in the load script.