### PR TITLE
Adding backwards compatibility with previous scaffold conventions

### DIFF
--- a/docs/tools/generate.template
+++ b/docs/tools/generate.template
@@ -3,6 +3,13 @@
 // (the generated documentation is stored in the 'docs/output' directory)
 // --------------------------------------------------------------------------------------
 
+// Binaries that have XML documentation (in a corresponding generated XML file)
+// Any binary output / copied to bin/projectName/projectName.dll will
+// automatically be added as a binary to generate API docs for.
+// for binaries output to root bin folder please add the filename only to the 
+// referenceBinaries list below in order to generate documentation for the binaries.
+// (This is the original behaviour of ProjectScaffold prior to multi project support)
+let referenceBinaries = []
 // Web site location for the generated documentation
 let website = "/##ProjectName##"
 
@@ -85,16 +92,26 @@ let references =
   else None
 
 let binaries =
-    directoryInfo bin 
-    |> subDirectories
-    |> Array.map (fun d -> d.FullName @@ (sprintf "%s.dll" d.Name))
-    |> List.ofArray
+    let manuallyAdded = 
+        referenceBinaries 
+        |> List.map (fun b -> bin @@ b)
+    
+    let conventionBased = 
+        directoryInfo bin 
+        |> subDirectories
+        |> Array.map (fun d -> d.FullName @@ (sprintf "%s.dll" d.Name))
+        |> List.ofArray
+
+    conventionBased @ manuallyAdded
 
 let libDirs =
-    directoryInfo bin 
-    |> subDirectories
-    |> Array.map (fun d -> d.FullName)
-    |> List.ofArray
+    let conventionBasedbinDirs =
+        directoryInfo bin 
+        |> subDirectories
+        |> Array.map (fun d -> d.FullName)
+        |> List.ofArray
+
+    conventionBasedbinDirs @ [bin]
 
 // Build API reference from XML comments
 let buildReference () =


### PR DESCRIPTION
Adding option to manually specify dlls to generate docs for in generate.fsx to provide upgrade path for
older projects.

Adresses the upgrade issues pointed out by @tpetricek in #153 

 