### PR TITLE
Always build docs to test the documentation generation on the CI

### DIFF
--- a/build.template
+++ b/build.template
@@ -342,8 +342,8 @@ Target "All" DoNothing
   ==> "Build"
   ==> "CopyBinaries"
   ==> "RunTests"
-  =?> ("GenerateReferenceDocs",isLocalBuild)
-  =?> ("GenerateDocs",isLocalBuild)
+  ==> "GenerateReferenceDocs"
+  ==> "GenerateDocs"
   ==> "All"
   =?> ("ReleaseDocs",isLocalBuild)
 


### PR DESCRIPTION
This basically ensures we don't get caught by surprise when the documentation generation starts failing (#156, #159 ,... )