### PR TITLE
Added .vs directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ ipch/
 *.vsp
 *.vspx
 
+# Other Visual Studio data
+.vs/
+
 # Guidance Automation Toolkit
 *.gpState
 


### PR DESCRIPTION
Based on [this suggestion][1], certain Visual Studio data is moving into a .vs directory. The contents aren't important for source control, so add it to the `.gitignore` file.

[1]: https://visualstudio.uservoice.com/forums/121579-visual-studio/suggestions/6079923-store-project-related-information-in-vs-folder-to