### PR TITLE
Set GitName to value provided during init

### DIFF
--- a/init.fsx
+++ b/init.fsx
@@ -176,7 +176,7 @@ let generate templatePath generatedFilePath =
     |> replaceWithVarOrMsg "##Author##" "Update Author in build.fsx" 
     |> replaceWithVarOrMsg "##Tags##" "" 
     |> replaceWithVarOrMsg "##GitHome##" "Update GitHome in build.fsx"
-    |> replace "##GitName##" projectName
+    |> replaceWithVarOrMsg "##GitName##" "Update GitName in build.fsx"
 
   File.WriteAllLines(generatedFilePath, newContent)
   File.Delete(templatePath)

--- a/init.fsx
+++ b/init.fsx
@@ -176,7 +176,7 @@ let generate templatePath generatedFilePath =
     |> replaceWithVarOrMsg "##Author##" "Update Author in build.fsx" 
     |> replaceWithVarOrMsg "##Tags##" "" 
     |> replaceWithVarOrMsg "##GitHome##" "Update GitHome in build.fsx"
-    |> replaceWithVarOrMsg "##GitName##" "Update GitName in build.fsx"
+    |> replaceWithVarOrMsg "##GitName##" projectName
 
   File.WriteAllLines(generatedFilePath, newContent)
   File.Delete(templatePath)


### PR DESCRIPTION
During the init phase GitName was not being set even if a GitName distinct from ProjectName was provided. The PR addresses that.