### PR TITLE
Fix FSharp.Formatting and FSharp.Compiler.Service

### DIFF
--- a/docs/tools/generate.template
+++ b/docs/tools/generate.template
@@ -27,8 +27,8 @@ let info =
 // For typical project, no changes are needed below
 // --------------------------------------------------------------------------------------
 
-#I "../../packages/FAKE/tools/"
 #load "../../packages/FSharp.Formatting/FSharp.Formatting.fsx"
+#I "../../packages/FAKE/tools/"
 #r "NuGet.Core.dll"
 #r "FakeLib.dll"
 open Fake


### PR DESCRIPTION
FSharp.Formatting, FSharp.Compiler.Service and FAKE have a special relation going on, causing newer FSharp.Formatting builds to fail generating documentation with this template. See https://github.com/tpetricek/FSharp.Formatting/issues/337#issuecomment-147828568 for more info.