### PR TITLE
Don't exclude packages/*/build/ from gitignore, because someone may h…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,6 @@ build/
 [Bb]in/
 [Oo]bj/
 
-# Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
-!packages/*/build/
-
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*


### PR DESCRIPTION
…ave a paket group called "Build"