### PR TITLE
Update paket.dependencies to keep NUnit version < 3

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,8 +1,8 @@
 source https://nuget.org/api/v2
 
 nuget FSharp.Formatting
-nuget NUnit 
-nuget NUnit.Runners
+nuget NUnit ~> 2
+nuget NUnit.Runners ~> 2
 nuget FAKE
 nuget SourceLink.Fake
 


### PR DESCRIPTION
NUnit3 changes the console-runners name to console-runner3 and modifies the command line parameters making the Fake task inoperable until support is added to Fake.