### PR TITLE
Propagate #define MONO to the projects too

### DIFF
--- a/build.template
+++ b/build.template
@@ -131,7 +131,11 @@ Target "CleanDocs" (fun _ ->
 
 Target "Build" (fun _ ->
     !! solutionFile
+#if MONO
+    |> MSBuildReleaseExt "" [ ("DefineConstants","MONO") ] "Rebuild"
+#else
     |> MSBuildRelease "" "Rebuild"
+#endif
     |> ignore
 )
 


### PR DESCRIPTION
Sometimes the projects compiled would benefit from knowing they are compiled in Mono too.