### PR TITLE
Parameterize Paket/FAKE binaries used in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,10 @@ set -o pipefail
 
 cd `dirname $0`
 
+PAKET_BOOTSTRAPPER_EXE=.paket/paket.bootstrapper.exe
+PAKET_EXE=.paket/paket.exe
+FAKE_EXE=packages/build/FAKE/tools/FAKE.exe
+
 FSIARGS=""
 OS=${OS:-"unknown"}
 if [[ "$OS" != "Windows_NT" ]]
@@ -21,7 +25,7 @@ function run() {
   fi
 }
 
-run .paket/paket.bootstrapper.exe
+run $PAKET_BOOTSTRAPPER_EXE
 
 if [[ "$OS" != "Windows_NT" ]] &&
        [ ! -e ~/.config/.mono/certs ]
@@ -29,9 +33,9 @@ then
   mozroots --import --sync --quiet
 fi
 
-run .paket/paket.exe restore
+run $PAKET_EXE restore
 
-[ ! -e build.fsx ] && run .paket/paket.exe update
-[ ! -e build.fsx ] && run packages/FAKE/tools/FAKE.exe init.fsx
-run packages/build/FAKE/tools/FAKE.exe "$@" $FSIARGS build.fsx
+[ ! -e build.fsx ] && run $PAKET_EXE update
+[ ! -e build.fsx ] && run $FAKE_EXE init.fsx
+run $FAKE_EXE "$@" $FSIARGS build.fsx
 


### PR DESCRIPTION
A previous commit (b612328) moved the location of FAKE.exe around but
missed updating every reference to it in build.sh. (This is why the Mono build is broken in CI).
This should make sure that doesn't happen again.