### PR TITLE
Don't run mozroots automatically; ask instead

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,9 +28,19 @@ function run() {
 run $PAKET_BOOTSTRAPPER_EXE
 
 if [[ "$OS" != "Windows_NT" ]] &&
-       [ ! -e ~/.config/.mono/certs ]
+       [ $(certmgr -list -c Trust | grep X.509 | wc -l) -le 1 ]
 then
-  mozroots --import --sync --quiet
+  echo "Your Mono installation has no trusted SSL root certificates set up."
+  echo "This may result in the Paket bootstrapper failing to download Paket"
+  echo "because Github's SSL certificate can't be verified. One way to fix"
+  echo "this issue would be to download the list of SSL root certificates"
+  echo "from the Mozilla project by running the following command:"
+  echo ""
+  echo "    mozroots --import --sync"
+  echo ""
+  echo "This will import over 100 SSL root certificates into your Mono"
+  echo "certificate repository. Then try running this script again."
+  exit 1
 fi
 
 run $PAKET_EXE restore

--- a/build.sh
+++ b/build.sh
@@ -25,10 +25,24 @@ function run() {
   fi
 }
 
+function yesno() {
+  # NOTE: Defaults to NO
+  read -p "$1 [y/N] " ynresult
+  case "$ynresult" in
+    [yY]*) true ;;
+    *) false ;;
+  esac
+}
+
+set +e
 run $PAKET_BOOTSTRAPPER_EXE
+bootstrapper_exitcode=$?
+set -e
 
 if [[ "$OS" != "Windows_NT" ]] &&
-       [ $(certmgr -list -c Trust | grep X.509 | wc -l) -le 1 ]
+       [ $bootstrapper_exitcode -ne 0 ] &&
+       [ $(certmgr -list -c Trust | grep X.509 | wc -l) -le 1 ] &&
+       [ $(certmgr -list -c -m Trust | grep X.509 | wc -l) -le 1 ]
 then
   echo "Your Mono installation has no trusted SSL root certificates set up."
   echo "This may result in the Paket bootstrapper failing to download Paket"
@@ -39,8 +53,17 @@ then
   echo "    mozroots --import --sync"
   echo ""
   echo "This will import over 100 SSL root certificates into your Mono"
-  echo "certificate repository. Then try running this script again."
-  exit 1
+  echo "certificate repository."
+  echo ""
+  if yesno "Run 'mozroots --import --sync' now?"
+  then
+    mozroots --import --sync
+  else
+    echo "Attempting to continue without running mozroots. This might fail."
+  fi
+  # Re-run bootstrapper whether or not the user ran mozroots, because maybe
+  # they fixed the problem in a separate terminal window.
+  run $PAKET_BOOTSTRAPPER_EXE
 fi
 
 run $PAKET_EXE restore


### PR DESCRIPTION
One of the most common reasons for the Paket bootstrapper to fail on Linux is if the Mono installation is brand-new -- because out of the box, Mono does not trust *any* X.509 root certificates. Therefore, GitHub's SSL certificate won't be trusted and Paket won't be downloaded.

The fix most often recommended is to run:

    mozroots --import --sync

which imports the entire root SSL certificate store trusted by the Mozilla project. This is over 100 certificates, so not everyone will want to run this command. (And we certainly shouldn't be running it for them.) But we should suggest it, because not everyone knows about the mozroots command. In particular, if someone is new to F# and Mono, this suggestion might save them hours of frustrated Google searches.

Note that the Mono project has said (in the [certmgr manpage][1]) that there is no guarantee that certificate store locations will stay the same between Mono releases, and that "The only safe way to interact with certificate stores is to use the certmgr tool." So instead of checking the `~/.config/.mono/certs` directory, we use certmgr to count the number of trusted X.509 certificates. We compare to 1 rather than 0 because the word "X.509" will appear once in the header of certmgr's output even on a system with no trusted root certs.

[1]: http://manpages.ubuntu.com/manpages/trusty/man1/certmgr.1.html

This fixes #235.