### PR TITLE
Handle directories containing whitespace properly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-cd `dirname $0`
+cd "$(dirname "$0")"
 
 FSIARGS=""
 OS=${OS:-"unknown"}


### PR DESCRIPTION
Fixes error, when the build script is invoked using a path containing whitespaces:
```

~ $ ./Internal\ Projects/fsharp/HParser/build.sh
Cannot open assembly '.paket/paket.bootstrapper.exe': Datei oder Verzeichnis nicht gefunden.

```