### PR TITLE
Fix ReleaseDocs before Build

### DIFF
--- a/build.template
+++ b/build.template
@@ -401,11 +401,11 @@ Target "All" DoNothing
 "GenerateHelpDebug"
   ==> "KeepRunning"
 
-"ReleaseDocs"
-  ==> "Release"
-
 "BuildPackage"
   ==> "PublishNuget"
   ==> "Release"
 
+"ReleaseDocs"
+  ==> "Release"
+  
 RunTargetOrDefault "All"


### PR DESCRIPTION
Hi, 

With current **Release targets sort order** when I call target release on **LocalBuild** my dependency graph looks like 
```
Building project with version: LocalBuild
Shortened DependencyGraph for Target Release:
<== Release
   <== ReleaseDocs
      <== All
         <== GenerateDocs
            <== GenerateReferenceDocs
               <== RunTests
                  <== CopyBinaries
                     <== Build
                        <== AssemblyInfo
                           <== Clean
               <== GenerateHelp
                  <== CleanDocs
   <== PublishNuget
      <== BuildPackage
         <== NuGet

The resulting target order is:
 - Clean
 - AssemblyInfo
 - Build
 - CopyBinaries
 - RunTests
 - CleanDocs
 - GenerateHelp
 - GenerateReferenceDocs
 - GenerateDocs
 - All
 - ReleaseDocs
 - NuGet
 - BuildPackage
 - PublishNuget
 - Release
```
When I build on my **jenkins server** my dependency graph looks like 
```
Building project with version:
Shortened DependencyGraph for Target Release:
<== Release
   <== ReleaseDocs
   <== PublishNuget
      <== BuildPackage
         <== NuGet
            <== All
               <== GenerateDocs
                  <== GenerateReferenceDocs
                     <== RunTests
                        <== CopyBinaries
                           <== Build
                              <== AssemblyInfo
                                 <== Clean
                     <== GenerateHelp
                        <== CleanDocs

The resulting target order is:
 - ReleaseDocs
 - Clean
 - AssemblyInfo
 - Build
 - CopyBinaries
 - RunTests
 - CleanDocs
 - GenerateHelp
 - GenerateReferenceDocs
 - GenerateDocs
 - All
 - NuGet
 - BuildPackage
 - PublishNuget
 - Release
```

As you can see **FAKE** try to call **ReleaseDocs target** first.
This line ```CopyRecursive "docs/output" tempDocsDir true |> tracefn "%A"``` will throw an exception because the folder "docs/output" is not already created.

Moving second definition of **Release target** after the other one fix the issue.

klettier