### PR TITLE
Parameterize Git url and Git raw url

### DIFF
--- a/build.template
+++ b/build.template
@@ -53,13 +53,13 @@ let testAssemblies = "tests/**/bin/Release/*Tests*.dll"
 // Git configuration (used for publishing documentation in gh-pages branch)
 // The profile where the project is posted
 let gitOwner = "##GitHome##"
-let gitHome = "https://github.com/" + gitOwner
+let gitHome = "##GitUrl##" + gitOwner
 
 // The name of the project on GitHub
 let gitName = "##GitName##"
 
 // The url for the raw files hosted
-let gitRaw = environVarOrDefault "gitRaw" "https://raw.github.com/##GitHome##"
+let gitRaw = environVarOrDefault "gitRaw" "##GitRawUrl##/##GitHome##"
 
 // --------------------------------------------------------------------------------------
 // END TODO: The rest of the file includes standard build steps

--- a/docs/tools/generate.template
+++ b/docs/tools/generate.template
@@ -13,7 +13,7 @@ let referenceBinaries = []
 // Web site location for the generated documentation
 let website = "/##ProjectName##"
 
-let githubLink = "http://github.com/##GitHome##/##GitName##"
+let githubLink = "##GitUrl##/##GitHome##/##GitName##"
 
 // Specify more information about your project
 let info =

--- a/init.fsx
+++ b/init.fsx
@@ -83,12 +83,17 @@ print """
 #
 """
 
+let [<Literal>] defaultGirUrl = "https://github.com"
+let [<Literal>] defaultGirRawUrl = "https://raw.githubusercontent.com"
+
 let vars = Dictionary<string,string option>()
 vars.["##ProjectName##"] <- promptForNoSpaces "Project Name (used for solution/project files)"
 vars.["##Summary##"]     <- promptFor "Summary (a short description)"
 vars.["##Description##"] <- promptFor "Description (longer description used by NuGet)"
 vars.["##Author##"]      <- promptFor "Author"
 vars.["##Tags##"]        <- promptFor "Tags (separated by spaces)"
+vars.["##GitUrl##"]      <- promptFor (sprintf "Github url (leave blank to use \"%s\")" defaultGirUrl)
+vars.["##GitRawUrl##"]   <- promptFor (sprintf "Github raw url (leave blank to use \"%s\")" defaultGirRawUrl)
 vars.["##GitHome##"]     <- promptFor "Github User or Organization"
 vars.["##GitName##"]     <- promptFor "Github Project Name (leave blank to use Project Name)"
 
@@ -158,6 +163,8 @@ let replaceContent file =
   |> replaceWithVarOrMsg "##Summary##" ""
   |> replaceWithVarOrMsg "##ProjectName##" ""
   |> replaceWithVarOrMsg "##Tags##" ""
+  |> replaceWithVarOrMsg "##GitUrl##" defaultGirUrl
+  |> replaceWithVarOrMsg "##GitRawUrl##" defaultGirRawUrl
   |> replaceWithVarOrMsg "##GitHome##" "[github-user]"
   |> replaceWithVarOrMsg "##GitName##" projectName
   |> overwrite file
@@ -189,6 +196,8 @@ let generate templatePath generatedFilePath =
     |> replaceWithVarOrMsg "##Description##" "Project has no description; update build.fsx"
     |> replaceWithVarOrMsg "##Author##" "Update Author in build.fsx"
     |> replaceWithVarOrMsg "##Tags##" ""
+    |> replaceWithVarOrMsg "##GitUrl##" defaultGirUrl
+    |> replaceWithVarOrMsg "##GitRawUrl##" defaultGirRawUrl
     |> replaceWithVarOrMsg "##GitHome##" "Update GitHome in build.fsx"
     |> replaceWithVarOrMsg "##GitName##" projectName
 

--- a/init.fsx
+++ b/init.fsx
@@ -83,8 +83,8 @@ print """
 #
 """
 
-let [<Literal>] defaultGirUrl = "https://github.com"
-let [<Literal>] defaultGirRawUrl = "https://raw.githubusercontent.com"
+let [<Literal>] defaultGitUrl = "https://github.com"
+let [<Literal>] defaultGitRawUrl = "https://raw.githubusercontent.com"
 
 let vars = Dictionary<string,string option>()
 vars.["##ProjectName##"] <- promptForNoSpaces "Project Name (used for solution/project files)"
@@ -92,8 +92,8 @@ vars.["##Summary##"]     <- promptFor "Summary (a short description)"
 vars.["##Description##"] <- promptFor "Description (longer description used by NuGet)"
 vars.["##Author##"]      <- promptFor "Author"
 vars.["##Tags##"]        <- promptFor "Tags (separated by spaces)"
-vars.["##GitUrl##"]      <- promptFor (sprintf "Github url (leave blank to use \"%s\")" defaultGirUrl)
-vars.["##GitRawUrl##"]   <- promptFor (sprintf "Github raw url (leave blank to use \"%s\")" defaultGirRawUrl)
+vars.["##GitUrl##"]      <- promptFor (sprintf "Github url (leave blank to use \"%s\")" defaultGitUrl)
+vars.["##GitRawUrl##"]   <- promptFor (sprintf "Github raw url (leave blank to use \"%s\")" defaultGitRawUrl)
 vars.["##GitHome##"]     <- promptFor "Github User or Organization"
 vars.["##GitName##"]     <- promptFor "Github Project Name (leave blank to use Project Name)"
 
@@ -163,8 +163,8 @@ let replaceContent file =
   |> replaceWithVarOrMsg "##Summary##" ""
   |> replaceWithVarOrMsg "##ProjectName##" ""
   |> replaceWithVarOrMsg "##Tags##" ""
-  |> replaceWithVarOrMsg "##GitUrl##" defaultGirUrl
-  |> replaceWithVarOrMsg "##GitRawUrl##" defaultGirRawUrl
+  |> replaceWithVarOrMsg "##GitUrl##" defaultGitUrl
+  |> replaceWithVarOrMsg "##GitRawUrl##" defaultGitRawUrl
   |> replaceWithVarOrMsg "##GitHome##" "[github-user]"
   |> replaceWithVarOrMsg "##GitName##" projectName
   |> overwrite file
@@ -196,8 +196,8 @@ let generate templatePath generatedFilePath =
     |> replaceWithVarOrMsg "##Description##" "Project has no description; update build.fsx"
     |> replaceWithVarOrMsg "##Author##" "Update Author in build.fsx"
     |> replaceWithVarOrMsg "##Tags##" ""
-    |> replaceWithVarOrMsg "##GitUrl##" defaultGirUrl
-    |> replaceWithVarOrMsg "##GitRawUrl##" defaultGirRawUrl
+    |> replaceWithVarOrMsg "##GitUrl##" defaultGitUrl
+    |> replaceWithVarOrMsg "##GitRawUrl##" defaultGitRawUrl
     |> replaceWithVarOrMsg "##GitHome##" "Update GitHome in build.fsx"
     |> replaceWithVarOrMsg "##GitName##" projectName
 

--- a/src/FSharp.ProjectTemplate/paket.template
+++ b/src/FSharp.ProjectTemplate/paket.template
@@ -6,11 +6,11 @@ owners
 authors 
     ##Author##
 projectUrl
-    http://github.com/##GitHome##/##GitName##
+    ##GitUrl##/##GitHome##/##GitName##
 iconUrl
-    https://raw.githubusercontent.com/##GitHome##/##GitName##/master/docs/files/img/logo.png
+    ##GitRawUrl##/##GitHome##/##GitName##/master/docs/files/img/logo.png
 licenseUrl
-    http://github.com/##GitHome##/##GitName##/blob/master/LICENSE.txt
+    ##GitUrl##/##GitHome##/##GitName##/blob/master/LICENSE.txt
 requireLicenseAcceptance
     false
 copyright


### PR DESCRIPTION
The company I am working for has his own private Github so the root domain urls aren't the same.
I would be nice to have the possibility to set those urls on scaffold init ?