### PR TITLE
Build configuration should default to Debug

### DIFF
--- a/build.template
+++ b/build.template
@@ -48,7 +48,7 @@ let tags = "##Tags##"
 let solutionFile  = "##ProjectName##.sln"
 
 // Default target configuration
-let configuration = "Release"
+let configuration = "Debug"
 
 // Pattern specifying assemblies to be tested using NUnit
 let testAssemblies = "tests/**/bin" </> configuration </> "*Tests*.dll"

--- a/build.template
+++ b/build.template
@@ -180,6 +180,7 @@ Target "NuGet" (fun _ ->
     Paket.Pack(fun p ->
         { p with
             OutputPath = "bin"
+            BuildConfig = configuration
             Version = release.NugetVersion
             ReleaseNotes = toLines release.Notes})
 )


### PR DESCRIPTION
When most people clone ProjectScaffold, they're just getting started with their project, not getting ready to release it. It would be more useful to let the default build configuration default to `Debug`, not `Release`.