### PR TITLE
Check that F# is installed in init.fsx

### DIFF
--- a/CheckFSharpInstallation.fsproj
+++ b/CheckFSharpInstallation.fsproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="CheckFSharpInstallation" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Target Name="CheckFSharpInstallation">
+    <Error Text="File Microsoft.FSharp.Targets not found. Is F# correctly installed on this system?" Condition="!Exists('$(FSharpTargetsPath)')" />
+  </Target>
+</Project>

--- a/init.fsx
+++ b/init.fsx
@@ -10,6 +10,31 @@ open System.Collections.Generic
 // It generates the build.fsx and generate.fsx files
 // --------------------------------
 
+let checkFSharpInstallation () =
+  try
+    MSBuildRelease "." "CheckFSharpInstallation" ["CheckFSharpInstallation.fsproj"] |> ignore
+    true
+  with e ->
+    false
+
+if File.Exists("CheckFSharpInstallation.fsproj") then
+  if checkFSharpInstallation() then
+    File.Delete "CheckFSharpInstallation.fsproj" // F# is installed, no need to check again if init.fsx gets run a second time somehow
+  else
+    traceError "F# does not seem to be installed."
+    if isMacOS then
+      traceError "Please install F# (see http://fsharp.org/use/mac/ for instructions),"
+    elif isWindows then
+      traceError "Please install F# (see http://fsharp.org/use/windows/ for instructions),"
+    elif isUnix then
+      traceError "Please install the \"fsharp\" package with your system's standard package manager,"
+      if isLinux then
+        traceError "(e.g., \"sudo apt-get install fsharp\" or \"sudo yum install fsharp\"),"
+    else
+      traceError "Please install F# (see http://fsharp.org/ for instructions),"
+    traceError "then run the build script again."
+    failwith "Build script aborted: please install F# and try again."
+
 let dirsWithProjects = ["src";"tests";"docs/content"]
                        |> List.map (fun d -> directoryInfo (__SOURCE_DIRECTORY__ @@ d))
 


### PR DESCRIPTION
If F# is not installed (say a Linux user has installed the `mono-complete` package, mistakenly thinking that F# was included in `mono-complete`), the error message that the user will see when he runs `build.sh` or `build.cmd` is "Target named 'Rebuild' not found in the project". Instead, we should check (once) in `init.fsx` to make sure that F# is properly installed, and give a clearer error message if it isn't.

This should fix #253.