### PR TITLE
Revert "Build configuration should default to Debug"

### DIFF
--- a/build.template
+++ b/build.template
@@ -48,7 +48,7 @@ let tags = "##Tags##"
 let solutionFile  = "##ProjectName##.sln"
 
 // Default target configuration
-let configuration = "Debug"
+let configuration = "Release"
 
 // Pattern specifying assemblies to be tested using NUnit
 let testAssemblies = "tests/**/bin" </> configuration </> "*Tests*.dll"
@@ -180,7 +180,6 @@ Target "NuGet" (fun _ ->
     Paket.Pack(fun p ->
         { p with
             OutputPath = "bin"
-            BuildConfig = configuration
             Version = release.NugetVersion
             ReleaseNotes = toLines release.Notes})
 )


### PR DESCRIPTION
Am reverting as ``build Release`` should turn on release mode