### PR TITLE
Addressing false negatives in the init scrip

### DIFF
--- a/CheckFSharpInstallation.fsproj
+++ b/CheckFSharpInstallation.fsproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="CheckFSharpInstallation" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>

--- a/init.fsx
+++ b/init.fsx
@@ -15,6 +15,7 @@ let checkFSharpInstallation () =
     MSBuildRelease "." "CheckFSharpInstallation" ["CheckFSharpInstallation.fsproj"] |> ignore
     true
   with e ->
+    traceImportant e.Message
     false
 
 if File.Exists("CheckFSharpInstallation.fsproj") then


### PR DESCRIPTION
Addresses false negatives in the init script (when checking if F# Tools are installed), by:

- Importing appropriate environment variables into MSBuild
- printing an error reported during init

