### PR TITLE
Be explicit about publish URL

### DIFF
--- a/build.template
+++ b/build.template
@@ -167,6 +167,7 @@ Target "NuGet" (fun _ ->
 Target "PublishNuget" (fun _ ->
     Paket.Push(fun p ->
         { p with
+            PublishUrl = "https://www.nuget.org"
             WorkingDir = "bin" })
 )
 


### PR DESCRIPTION
See https://github.com/fsprojects/Paket/issues/1817, this allows the use of ``paket config add-token`` on ``https://www.nuget.org``.  Without the key isn't found, see https://github.com/fsprojects/Paket/issues/1817

    paket config add-token "https://www.nuget.org" 4003d786-cc37-4004-bfdf-c4f3e8ef9b3a