### PR TITLE
Fix GenerateDoc failed in Mono (macos)

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -14,7 +14,7 @@ group Build
   source https://nuget.org/api/v2
   
   nuget FAKE
-  nuget FSharp.Formatting
+  nuget FSharp.Formatting 3.0.0-beta01
 
   github fsharp/FAKE modules/Octokit/Octokit.fsx
 


### PR DESCRIPTION
When I run `./build.sh` in macos, I got an error:
```sh
Mono.CSharp.InternalErrorException: Failed to import assembly `Argu, Version=3.3.0.0, Culture=neutral, PublicKeyToken=null' ---> System.ArgumentException: Value does not fall within the expected range.
```

After digging a while, I find this issue: https://github.com/fsprojects/FSharp.Formatting/issues/412 nothing helped.
But when I git cloned the FSharp.Formating repo and built, it didn't fail, so I upgrade the dep in ProjectScaffold, succeed!