### PR TITLE
Clear git history when cloned via ssh or https

### DIFF
--- a/init.fsx
+++ b/init.fsx
@@ -255,10 +255,10 @@ let setRemote (name,url) workingDir =
     | x -> traceException x
 
 let isRemote (name,url) value =
-  let remote = getRegEx <| sprintf @"^%s\s+%s\s+\(push\)$" name url
+  let remote = getRegEx <| sprintf @"^%s\s+(https?:\/\/|git@)github.com(\/|:)%s\s+\(push\)$" name url
   remote.IsMatch value
 
-let isScaffoldRemote = isRemote ("origin","http://github.com/fsprojects/ProjectScaffold.git")
+let isScaffoldRemote = isRemote ("origin","fsprojects/ProjectScaffold.git")
 
 let hasScaffoldOrigin () =
   try


### PR DESCRIPTION
Fixes https://github.com/fsprojects/ProjectScaffold/issues/276. When the ProjectScaffold repo has been cloned via ssh or https the "Initialise git repo" step does not work correctly. This is because the check performed to see if the remote matches the ProjectScaffold repo only tests for the following remote url format:

``http://github.com/fsprojects/ProjectScaffold.git``

This fix adds support for the additional remote url formats:

``https://github.com/fsprojects/ProjectScaffold.git``

and

``git@github.com:fsprojects/ProjectScaffold.git``

to correctly handle when the repo has been cloned by https or ssh.