### PR TITLE
Clear git history when remote does not end in .git

### DIFF
--- a/init.fsx
+++ b/init.fsx
@@ -255,10 +255,10 @@ let setRemote (name,url) workingDir =
     | x -> traceException x
 
 let isRemote (name,url) value =
-  let remote = getRegEx <| sprintf @"^%s\s+(https?:\/\/|git@)github.com(\/|:)%s\s+\(push\)$" name url
+  let remote = getRegEx <| sprintf @"^%s\s+(https?:\/\/|git@)github.com(\/|:)%s(\.git)?\s+\(push\)$" name url
   remote.IsMatch value
 
-let isScaffoldRemote = isRemote ("origin","fsprojects/ProjectScaffold.git")
+let isScaffoldRemote = isRemote ("origin","fsprojects/ProjectScaffold")
 
 let hasScaffoldOrigin () =
   try


### PR DESCRIPTION
Fixes #315. When the ProjectScaffold repo is cloned via copy-and-paste from the browser's address bar, its remote ends up looking like https://github.com/fsprojects/ProjectScaffold (without .git at the end). This PR ensures that that URL will be matched when deciding whether to erase ProjectScaffold history in the initial project setup phase.