### PR TITLE
Fix docs with new way of specifying the target

### DIFF
--- a/running-tests.html
+++ b/running-tests.html
@@ -41,7 +41,7 @@
 </pre>
 </td>
 <td class="snippet"><pre class="fssnip">
-<span class="o">$</span> <span class="i">build</span> <span class="i">RunTests</span></pre>
+<span class="o">$</span> <span class="i">build</span> <span class="i">-t</span> <span class="i">RunTests</span></pre>
 </td>
 </tr>
 </table>


### PR DESCRIPTION
`build RunTests` is no longer valid.