### PR TITLE
Fix comment about specifying target

### DIFF
--- a/build.template
+++ b/build.template
@@ -375,7 +375,7 @@ Target.create "BuildPackage" ignore
 Target.create "GenerateDocs" ignore
 
 // --------------------------------------------------------------------------------------
-// Run all targets by default. Invoke 'build <Target>' to override
+// Run all targets by default. Invoke 'build -t <Target>' to override
 
 Target.create "All" ignore
 


### PR DESCRIPTION
`build <Target>` doesn't work anymore