### PR TITLE
update docs to note FAKE installation requirements, and links to FAKE website

### DIFF
--- a/docs/content/fake-build.md
+++ b/docs/content/fake-build.md
@@ -1,6 +1,6 @@
 # FAKE build
 
-ProjectScaffold uses the [FAKE](http://fsharp.github.io/FAKE/) build tool to automate the complete build and release process for a application/solution.
+ProjectScaffold uses the [FAKE](https://fake.build/) build tool to automate the complete build and release process for a application/solution.
 
 The `build.fsx` file contains this logic and is written in FAKE's build DSL. It contains a number of common tasks (i.e. build targets) such as directory cleaning, unit test execution, and NuGet package creation. You are encouraged to adapt existing build targets and/or add new ones as necessary. 
 
@@ -17,7 +17,7 @@ However, if you are leveraging the default conventions, as established in this s
   - `authors` - A list of author names, to be displayed in the NuGet package metadata.
   - `tags` - A string containing space-separated tags, to be included in the NuGet package metadata.
   - `solutionFile` - The name of your solution file (sans-extension). It is used as part of the build process.
-  - `testAssemblies` - A list of [FAKE](http://fsharp.github.io/FAKE/) globbing patterns to be searched for unit-test assemblies.
+  - `testAssemblies` - A list of [FAKE](https://fake.build/) globbing patterns to be searched for unit-test assemblies.
   - `gitHome` - The base URL / user profile hosting this project's GitHub repository. This is used for publishing documentation.
   - `gitName` - The name of this project's GitHub repository. This is used for publishing documentation.
 
@@ -30,4 +30,4 @@ You can run any target in the build script using:
     
 If you don't specify a target name it will run the default process, which includes running tests and [building docs](writing-docs.html).
     
-More details can be found in the [FAKE docs](http://fsharp.github.io/FAKE/).
+More details can be found in the [FAKE](https://fake.build/) docs.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -27,6 +27,10 @@ FAKE:
 
 The first thing to do is to [clone](https://github.com/fsprojects/ProjectScaffold.git) or [copy](https://github.com/fsprojects/ProjectScaffold/archive/master.zip) the ProjectScaffold repository to your developer workspace. This will eventually be your solution folder. Feel free to rename ProjectScaffold folder to your liking.
 
+You will need to have either a global or local installation of the [FAKE](https://fake.build/) build tool, in order to run the build scripts. More detailed instructions can be found [here](https://fake.build/fake-gettingstarted.html). If you want to perform a global installation, and you have .NET Core 2.1 or later installed, run:
+
+    $ dotnet tool install fake-cli -g
+
 ### Initializing
 
 In order to generate your project first run:

--- a/docs/content/running-tests.md
+++ b/docs/content/running-tests.md
@@ -6,7 +6,7 @@ By default ProjectScaffold uses [NUnit](http://www.nunit.org/) as test framework
 
 ## Changing the test framework
 
-[FAKE](http://fsharp.github.io/FAKE/) supports many different test frameworks including [xUnit](http://xunit.github.io/), [Machine.Specifications](https://github.com/machine/machine.specifications) and many more.    
+[FAKE](https://fake.build/) supports many different test frameworks including [xUnit](http://xunit.github.io/), [Machine.Specifications](https://github.com/machine/machine.specifications) and many more.    
 
 If you wish to use a different test framework, look for the `RunTest` target in the `build.fsx` file:
 
@@ -21,4 +21,4 @@ If you wish to use a different test framework, look for the `RunTest` target in 
     
 You will also ant to change the testing framework in the `paket.dependencies` file and run the [update process](paket-package-management.html#Updating-packages).
 
-More details regarding these aspects can be found in the [FAKE](http://fsharp.github.io/FAKE/) and [Paket](http://fsprojects.github.io/Paket/) documentation sites.
+More details regarding these aspects can be found in the [FAKE](https://fake.build/) and [Paket](http://fsprojects.github.io/Paket/) documentation sites.

--- a/docs/content/technologies.md
+++ b/docs/content/technologies.md
@@ -5,7 +5,7 @@
 | Area                      |  Technologies                             |
 |:--------------------------|:------------------------------------------|
 | Platforms                 | Linux, Windows, OSX                       |
-| Build Automation          | [FAKE](http://fsharp.github.io/FAKE/)     |
+| Build Automation          | [FAKE](https://fake.build/)               |
 | Unit Testing              | [NUnit](http://www.nunit.org/)            |
 | Package Formats           | NuGet packages                            |
 | Dependency Manager        | [Paket](http://fsprojects.github.io/Paket/) |


### PR DESCRIPTION
Update the docs to note that you need to have either a global or local installation of FAKE, to run the generated build scripts. Also, update links to FAKE to point to the new https://fake.build/ website.